### PR TITLE
feat: add --side-drawer-transition css variable

### DIFF
--- a/README.md
+++ b/README.md
@@ -87,20 +87,14 @@ side-drawer {
 }
 ```
 
-You can set a backdrop filter using the following CSS variable.
+You can customize styling with the following CSS variables:
 
-- `--side-drawer-backdrop-filter`
-  - Sets the backdrop-filter for both the drawer and the overlay that appears to the right of the drawer (when it's open).
-  - Default is `none`
-
-You can customize the overlay that appears to the right of the drawer (when it's open) by setting one of the following CSS variables.
-
-- `--side-drawer-overlay-transition`
-  - Sets the transition
-  - Default is `opacity 0.25s ease-in-out 0.25s`
-- `--side-drawer-overlay-opacity`
-  - Sets the opacity of the overlay
-  - Default is `0.7`
+| Variable | Default | Description |
+| -------- | ----------- | ------- |
+| `--side-drawer-transition` | `transform 0.25s ease-out` | The open/close transition for the drawer |
+| `--side-drawer-backdrop-filter` | `none` | The backdrop-filter for both the drawer and the overlay that appears to the right of the drawer (when it's open) |
+| `--side-drawer-overlay-transition`| `opacity linear 0.25s` | The transition for the overlay that appears to the right of the drawer (when it's open) |
+| `--side-drawer-overlay-opacity` | `0.7` | The opacity of the overlay |
 
 ## Contribute
 

--- a/README.md
+++ b/README.md
@@ -89,12 +89,12 @@ side-drawer {
 
 You can customize styling with the following CSS variables:
 
-| Variable | Default | Description |
-| -------- | ----------- | ------- |
-| `--side-drawer-transition` | `transform 0.25s ease-out` | The open/close transition for the drawer |
-| `--side-drawer-backdrop-filter` | `none` | The backdrop-filter for both the drawer and the overlay that appears to the right of the drawer (when it's open) |
-| `--side-drawer-overlay-transition`| `opacity linear 0.25s` | The transition for the overlay that appears to the right of the drawer (when it's open) |
-| `--side-drawer-overlay-opacity` | `0.7` | The opacity of the overlay |
+| Variable                           | Default                    | Description                                                                                                      |
+| ---------------------------------- | -------------------------- | ---------------------------------------------------------------------------------------------------------------- |
+| `--side-drawer-transition`         | `transform 0.25s ease-out` | The open/close transition for the drawer                                                                         |
+| `--side-drawer-backdrop-filter`    | `none`                     | The backdrop-filter for both the drawer and the overlay that appears to the right of the drawer (when it's open) |
+| `--side-drawer-overlay-transition` | `opacity linear 0.25s`     | The transition for the overlay that appears to the right of the drawer (when it's open)                          |
+| `--side-drawer-overlay-opacity`    | `0.7`                      | The opacity of the overlay                                                                                       |
 
 ## Contribute
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "side-drawer",
-  "version": "3.0.0",
+  "version": "3.1.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "side-drawer",
-  "version": "3.0.0",
+  "version": "3.1.0",
   "description": "A simple side drawer element with no dependencies and small as possible",
   "keywords": [
     "web component",

--- a/side-drawer.js
+++ b/side-drawer.js
@@ -33,7 +33,10 @@ const style = `
   height: 100%;
   box-sizing: border-box;
   transform: translateX(-100%);
-  transition: transform 0.5s cubic-bezier(0.4, 0, 0.2, 1);
+  transition: var(
+    --side-drawer-transition,
+    transform 0.25s ease-out
+  );
   width: inherit;
   max-width: inherit;
   border-top-right-radius: inherit;
@@ -57,7 +60,7 @@ const style = `
   height: 100vh;
   transition: var(
     --side-drawer-overlay-transition,
-    opacity 0.25s ease-in-out 0.25s
+    opacity linear 0.25s
   );
   width: calc(
     100vw + 30px


### PR DESCRIPTION
I changed the transform transition duration to 250ms and switched to ease-out to better match the default drawer open speed on Android. I also removed the delay on the opacity transform and changed to linear.
I also exposed the main transition as `--side-drawer-transition`